### PR TITLE
1.2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ with the method *send*.
         <dependency>
             <groupId>com.ubirch</groupId>
             <artifactId>ubirch-kafka-express</artifactId>
-            <version>1.2.11-SNAPSHOT</version>
+            <version>1.2.13-SNAPSHOT</version>
         </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <!-- ensure compiler version -->
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <scala.version>2.12.6</scala.version>
+        <scala.version>2.12.8</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
         <scalatest.version>3.0.5</scalatest.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -68,13 +68,12 @@
 
         <!-- versions -->
 
-        <event-log-util.version>1.2.5-SNAPSHOT</event-log-util.version>
-        <io.monix.version>2.3.2</io.monix.version>
+        <io.monix.version>3.1.0</io.monix.version>
         <kafka-clients.version>2.3.0</kafka-clients.version>
+        <embedded-kafka>2.3.0</embedded-kafka>
         <json4s-native.version>3.6.0</json4s-native.version>
         <json4s-jackson.version>3.6.1</json4s-jackson.version>
         <json4s-ext>3.6.0</json4s-ext>
-        <embedded-kafka>2.3.0</embedded-kafka>
 
         <scala.logging.version>3.9.0</scala.logging.version>
         <slf4j.api.version>1.7.15</slf4j.api.version>
@@ -82,6 +81,7 @@
         <log4j-over-slf4j.version>1.7.25</log4j-over-slf4j.version>
         <jcl-over-slf4j.version>1.7.25</jcl-over-slf4j.version>
         <logstash-logback-encoder.version>5.3</logstash-logback-encoder.version>
+
         <io.prometheus.simpleclient.version>0.6.0</io.prometheus.simpleclient.version>
         <io.prometheus.simpleclient_hotspot.version>0.6.0</io.prometheus.simpleclient_hotspot.version>
         <io.prometheus.simpleclient_httpserver.version>0.6.0</io.prometheus.simpleclient_httpserver.version>
@@ -109,7 +109,6 @@
             <artifactId>config</artifactId>
             <version>1.3.2</version>
         </dependency>
-
 
         <!-- https://mvnrepository.com/artifact/io.monix/monix -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <!-- basic info -->
     <groupId>com.ubirch</groupId>
     <artifactId>ubirch-kafka-express</artifactId>
-    <version>1.2.12-SNAPSHOT</version>
+    <version>1.2.13-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>Simple wrapper for starting a kafka consumer or producer very quickly</description>
     <url>https://ubirch.com</url>
@@ -31,10 +31,10 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/ubirch/ubirch-event-log.git</connection>
-        <developerConnection>scm:git:git@github.com:ubirch/ubirch-event-log.git</developerConnection>
-        <url>https://github.com/ubirch/ubirch-event-log</url>
-        <tag>event-log-kafka-1.2.8-SNAPSHOT</tag>
+        <connection>scm:git:git@github.com:ubirch/ubirch-kafka-express.git</connection>
+        <developerConnection>scm:git:git@github.com:ubirch/ubirch-kafka-express.git</developerConnection>
+        <url>https://github.com/ubirch/ubirch-kafka-express</url>
+        <tag>1.2.13-SNAPSHOT</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/scala/com/ubirch/kafka/consumer/ConsumerRunner.scala
+++ b/src/main/scala/com/ubirch/kafka/consumer/ConsumerRunner.scala
@@ -157,7 +157,7 @@ abstract class ConsumerRunner[K, V](name: String)(implicit val scheduler: Schedu
             }
           } finally {
             //this is in a try to guaranty its execution.
-            postConsumeCallback.run(totalPolledCount)
+            val _ = postConsumeCallback.run(totalPolledCount)
           }
 
           //This is a listener on other exception for when the consumer is not paused.
@@ -258,7 +258,7 @@ abstract class ConsumerRunner[K, V](name: String)(implicit val scheduler: Schedu
 
     val pauseDuration = getPauseDuration.toMillis
 
-    val amortized = scala.math.pow(2, ps).toInt * pauseDuration
+    val amortized = scala.math.pow(2, ps.toDouble).toInt * pauseDuration
 
     FiniteDuration(amortized, MILLISECONDS)
 

--- a/src/main/scala/com/ubirch/kafka/consumer/ConsumerRunner.scala
+++ b/src/main/scala/com/ubirch/kafka/consumer/ConsumerRunner.scala
@@ -5,9 +5,8 @@ import java.util.UUID
 import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger, AtomicReference }
 
 import com.ubirch.kafka.util.Exceptions._
-import com.ubirch.kafka.util.{ Callback, Callback0, VersionedLazyLogging }
+import com.ubirch.kafka.util.{ Callback, Callback0, FutureHelper, VersionedLazyLogging }
 import com.ubirch.util.ShutdownableThread
-import com.ubirch.kafka.util.FutureHelper
 import monix.execution.Scheduler
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
@@ -15,8 +14,8 @@ import org.apache.kafka.common.serialization.Deserializer
 
 import scala.beans.BeanProperty
 import scala.collection.JavaConverters._
+import scala.concurrent.Future
 import scala.concurrent.duration.{ FiniteDuration, _ }
-import scala.concurrent.{ ExecutionContext, Future }
 import scala.language.postfixOps
 
 /**
@@ -31,13 +30,11 @@ import scala.language.postfixOps
   * @tparam K Represents the type of the Key for the consumer.
   * @tparam V Represents the type of the Value for the consumer.
   */
-abstract class ConsumerRunner[K, V](name: String)(implicit val ec: ExecutionContext)
+abstract class ConsumerRunner[K, V](name: String)(implicit val scheduler: Scheduler)
   extends ShutdownableThread(name)
   with ConsumerRebalanceListener
   with WithProcessRecords[K, V]
   with VersionedLazyLogging {
-
-  implicit lazy val scheduler: Scheduler = monix.execution.Scheduler(ec)
 
   override val version: AtomicInteger = ConsumerRunner.version
   //This one is made public for testing purposes
@@ -384,7 +381,7 @@ abstract class ConsumerRunner[K, V](name: String)(implicit val ec: ExecutionCont
 object ConsumerRunner {
   val version: AtomicInteger = new AtomicInteger(0)
 
-  def fBased[K, V](f: Vector[ConsumerRecord[K, V]] => Future[ProcessResult[K, V]])(implicit executionContext: ExecutionContext): ConsumerRunner[K, V] = {
+  def fBased[K, V](f: Vector[ConsumerRecord[K, V]] => Future[ProcessResult[K, V]])(implicit scheduler: Scheduler): ConsumerRunner[K, V] = {
     new ConsumerRunner[K, V](name) {
       override def process(consumerRecords: Vector[ConsumerRecord[K, V]]): Future[ProcessResult[K, V]] = {
         f(consumerRecords)
@@ -392,15 +389,15 @@ object ConsumerRunner {
     }
   }
 
-  def controllerBased[K, V](controller: ConsumerRecordsController[K, V])(implicit ec: ExecutionContext): ConsumerRunner[K, V] = {
+  def controllerBased[K, V](controller: ConsumerRecordsController[K, V])(implicit scheduler: Scheduler): ConsumerRunner[K, V] = {
     val consumer = empty[K, V]
     consumer.setConsumerRecordsController(Some(controller))
     consumer
   }
 
-  def empty[K, V](implicit executionContext: ExecutionContext): ConsumerRunner[K, V] = new ConsumerRunner[K, V](name) {}
+  def empty[K, V](implicit scheduler: Scheduler): ConsumerRunner[K, V] = new ConsumerRunner[K, V](name) {}
 
-  def emptyWithMetrics[K, V](prefix: String, metricsSubNamespace: String)(implicit executionContext: ExecutionContext): ConsumerRunner[K, V] = {
+  def emptyWithMetrics[K, V](prefix: String, metricsSubNamespace: String)(implicit scheduler: Scheduler): ConsumerRunner[K, V] = {
     new ConsumerRunner[K, V](name) with WithMetrics {
       override def metricsSubNamespaceLabel: String = metricsSubNamespace
       override def prefixNamespace: String = prefix

--- a/src/main/scala/com/ubirch/kafka/consumer/Consumers.scala
+++ b/src/main/scala/com/ubirch/kafka/consumer/Consumers.scala
@@ -1,30 +1,31 @@
 package com.ubirch.kafka.consumer
 
+import monix.execution.Scheduler
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.Future
 
 /**
   * Represents a Basic String Consumer
-  * @param ec Represents the execution context.
+  * @param scheduler Represents the execution scheduler.
   */
-abstract class StringConsumer(implicit ec: ExecutionContext) extends ConsumerRunner[String, String](ConsumerRunner.name)
+abstract class StringConsumer(implicit scheduler: Scheduler) extends ConsumerRunner[String, String](ConsumerRunner.name)
 
 /**
   * Contains useful helpers for a StringConsumer
   */
 object StringConsumer {
 
-  def empty(implicit ec: ExecutionContext): StringConsumer = new StringConsumer() {}
+  def empty(implicit scheduler: Scheduler): StringConsumer = new StringConsumer() {}
 
-  def emptyWithMetrics(prefix: String, metricsSubNamespace: String)(implicit ec: ExecutionContext): StringConsumer = new StringConsumer() with WithMetrics {
+  def emptyWithMetrics(prefix: String, metricsSubNamespace: String)(implicit scheduler: Scheduler): StringConsumer = new StringConsumer() with WithMetrics {
 
     override def prefixNamespace: String = prefix
 
     override def metricsSubNamespaceLabel: String = metricsSubNamespace
   }
 
-  def fBased(f: Vector[ConsumerRecord[String, String]] => Future[ProcessResult[String, String]])(implicit ec: ExecutionContext): StringConsumer = {
+  def fBased(f: Vector[ConsumerRecord[String, String]] => Future[ProcessResult[String, String]])(implicit scheduler: Scheduler): StringConsumer = {
     new StringConsumer() {
       override def process(consumerRecords: Vector[ConsumerRecord[String, String]]): Future[ProcessResult[String, String]] = {
         f(consumerRecords)
@@ -32,7 +33,7 @@ object StringConsumer {
     }
   }
 
-  def controllerBased(controller: ConsumerRecordsController[String, String])(implicit ec: ExecutionContext): StringConsumer = {
+  def controllerBased(controller: ConsumerRecordsController[String, String])(implicit scheduler: Scheduler): StringConsumer = {
     val consumer = empty
     consumer.setConsumerRecordsController(Some(controller))
     consumer
@@ -42,23 +43,23 @@ object StringConsumer {
 
 /**
   * Represents a Basic Bytes Consumer
-  * @param ec Represents the execution context.
+  * @param scheduler Represents the execution scheduler.
   */
-abstract class BytesConsumer(implicit ec: ExecutionContext) extends ConsumerRunner[String, Array[Byte]](ConsumerRunner.name)
+abstract class BytesConsumer(implicit scheduler: Scheduler) extends ConsumerRunner[String, Array[Byte]](ConsumerRunner.name)
 
 /**
   * Contains useful helpers for a  BytesConsumer
   */
 object BytesConsumer {
 
-  def empty(implicit ec: ExecutionContext): BytesConsumer = new BytesConsumer() {}
+  def empty(implicit scheduler: Scheduler): BytesConsumer = new BytesConsumer() {}
 
-  def emptyWithMetrics(prefix: String, metricsSubNamespace: String)(implicit ec: ExecutionContext): BytesConsumer = new BytesConsumer() with WithMetrics {
+  def emptyWithMetrics(prefix: String, metricsSubNamespace: String)(implicit scheduler: Scheduler): BytesConsumer = new BytesConsumer() with WithMetrics {
     override def prefixNamespace: String = prefix
     override def metricsSubNamespaceLabel: String = metricsSubNamespace
   }
 
-  def fBased(f: Vector[ConsumerRecord[String, Array[Byte]]] => Future[ProcessResult[String, Array[Byte]]])(implicit ec: ExecutionContext): BytesConsumer = {
+  def fBased(f: Vector[ConsumerRecord[String, Array[Byte]]] => Future[ProcessResult[String, Array[Byte]]])(implicit scheduler: Scheduler): BytesConsumer = {
     new BytesConsumer() {
       override def process(consumerRecords: Vector[ConsumerRecord[String, Array[Byte]]]): Future[ProcessResult[String, Array[Byte]]] = {
         f(consumerRecords)
@@ -66,7 +67,7 @@ object BytesConsumer {
     }
   }
 
-  def controllerBased(controller: ConsumerRecordsController[String, Array[Byte]])(implicit ec: ExecutionContext): BytesConsumer = {
+  def controllerBased(controller: ConsumerRecordsController[String, Array[Byte]])(implicit scheduler: Scheduler): BytesConsumer = {
     val consumer = empty
     consumer.setConsumerRecordsController(Some(controller))
     consumer

--- a/src/main/scala/com/ubirch/kafka/consumer/WithConsumerShutdownHook.scala
+++ b/src/main/scala/com/ubirch/kafka/consumer/WithConsumerShutdownHook.scala
@@ -9,7 +9,7 @@ trait WithConsumerShutdownHook extends LazyLogging {
     () =>
       logger.info(s"Shutting down Consumer[timeout=$gracefulTimeout secs name=${consumerRunner.getName}] ...")
       if (Option(consumerRunner).isDefined)
-        Future.successful(consumerRunner.shutdown(gracefulTimeout, java.util.concurrent.TimeUnit.SECONDS))
+        Future.successful(consumerRunner.shutdown(gracefulTimeout.toLong, java.util.concurrent.TimeUnit.SECONDS))
       else Future.unit
   }
 }

--- a/src/main/scala/com/ubirch/kafka/consumer/WithMetrics.scala
+++ b/src/main/scala/com/ubirch/kafka/consumer/WithMetrics.scala
@@ -70,8 +70,8 @@ trait WithMetrics extends WithNamespace {
 
   onPostConsume { count =>
     if (count > 0) {
-      pollSizeSummary.labels(metricsSubNamespaceLabel).observe(count)
-      pollConsumeTimer.observeDuration()
+      pollSizeSummary.labels(metricsSubNamespaceLabel).observe(count.toDouble)
+      val _ = pollConsumeTimer.observeDuration()
     }
   }
   //Metrics Def End

--- a/src/main/scala/com/ubirch/kafka/consumer/WithProcessRecords.scala
+++ b/src/main/scala/com/ubirch/kafka/consumer/WithProcessRecords.scala
@@ -13,7 +13,6 @@ import org.apache.kafka.common.errors.TimeoutException
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.util.{ Failure, Success }
 
 trait WithProcessRecords[K, V] {
@@ -36,7 +35,7 @@ trait WithProcessRecords[K, V] {
       finish()
     }
 
-    def processRecords(consumerRecords: Vector[ConsumerRecord[K, V]]) {
+    def processRecords(consumerRecords: Vector[ConsumerRecord[K, V]]) = {
       val processing = process(consumerRecords)
       processing.onComplete {
         case Success(_) =>
@@ -75,7 +74,7 @@ trait WithProcessRecords[K, V] {
 
     override protected val batchCountDownSize: Int = partitionRecordsSize
 
-    def start() {
+    def start() = {
       if (getDelaySingleRecord == 0.millis && getDelayRecords == 0.millis) {
         partitionRecords.foreach(x => processRecords(Vector(x)))
       } else {
@@ -93,7 +92,7 @@ trait WithProcessRecords[K, V] {
         postCommitCallback.run(partitionRecordsSize)
       } catch {
         case e: TimeoutException =>
-          throw CommitTimeoutException("Commit timed out", () => this.commitFunc(), e)
+          throw CommitTimeoutException("Commit timed out", () => { val _ = this.commitFunc() }, e)
         case e: Throwable =>
           throw e
       }
@@ -124,7 +123,7 @@ trait WithProcessRecords[K, V] {
 
     protected val batchCountDownSize: Int = 1
 
-    def start() {
+    def start() = {
       processRecords(consumerRecords.iterator().asScala.toVector)
       if (getDelayRecords > 0.millis) {
         FutureHelper.delay(getDelayRecords)(())
@@ -138,7 +137,7 @@ trait WithProcessRecords[K, V] {
         postCommitCallback.run(consumerRecords.count())
       } catch {
         case e: TimeoutException =>
-          throw CommitTimeoutException("Commit timed out", () => this.commitFuncUpgraded(), e)
+          throw CommitTimeoutException("Commit timed out", () => { val _ = this.commitFuncUpgraded() }, e)
         case e: Throwable =>
           throw e
       }

--- a/src/main/scala/com/ubirch/kafka/express/ExpressKafkaApp.scala
+++ b/src/main/scala/com/ubirch/kafka/express/ExpressKafkaApp.scala
@@ -102,8 +102,8 @@ trait ExpressKafka[K, V, R] extends ExpressConsumer[K, V] with ExpressProducer[K
   lazy val controller: ConsumerRecordsController[K, V] = new ConsumerRecordsController[K, V] {
 
     def simpleProcessResult(consumerRecord: Vector[ConsumerRecord[K, V]]): ProcessResult[K, V] = new ProcessResult[K, V] {
-      override val id: UUID = UUID.randomUUID()
-      override val consumerRecords: Vector[ConsumerRecord[K, V]] = consumerRecord
+      override lazy val id: UUID = UUID.randomUUID()
+      override lazy val consumerRecords: Vector[ConsumerRecord[K, V]] = consumerRecord
     }
 
     override type A = ProcessResult[K, V]

--- a/src/main/scala/com/ubirch/kafka/producer/ProducerRunner.scala
+++ b/src/main/scala/com/ubirch/kafka/producer/ProducerRunner.scala
@@ -78,15 +78,14 @@ abstract class ProducerRunner[K, V] extends VersionedLazyLogging {
       case e: Exception =>
         throw ProducerCreationException("Error Creating Producer", e.getMessage)
     } finally {
-      onPostProducerCreation.run(getProducerAsOpt)
+      val _ = onPostProducerCreation.run(getProducerAsOpt)
     }
 
   }
 
   def close(timout: FiniteDuration): Unit = {
-    getProducerAsOpt
+    val _ = getProducerAsOpt
       .map(_.close(java.time.Duration.ofMillis(timout.toMillis)))
-      .getOrElse(Unit)
   }
 
   def getProducerAsOpt: Option[Producer[K, V]] = producer
@@ -117,7 +116,7 @@ abstract class ProducerRunner[K, V] extends VersionedLazyLogging {
   }
 
   def sendWithCallback(record: ProducerRecord[K, V])(callback: Try[RecordMetadata] => Unit): Unit = {
-    getProducerOrCreate.send(record, producerCallback(callback))
+    val _ = getProducerOrCreate.send(record, producerCallback(callback))
   }
 
 }

--- a/src/main/scala/com/ubirch/kafka/util/Implicits.scala
+++ b/src/main/scala/com/ubirch/kafka/util/Implicits.scala
@@ -1,8 +1,13 @@
 package com.ubirch.kafka.util
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import monix.execution.Scheduler
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.joda.time.{ Duration, Instant }
 
+import scala.collection.JavaConverters._
+import scala.collection.breakOut
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 import scala.language.implicitConversions
@@ -39,6 +44,23 @@ case class EnrichedInstant(instant: Instant) {
 
 }
 
+case class EnrichedConsumerRecord[K, V](cr: ConsumerRecord[K, V]) extends AnyVal {
+
+  def findHeader(key: String): Option[String] = {
+    cr.headers()
+      .asScala
+      .find(h => h.key().toLowerCase == key.toLowerCase)
+      .map(h => new String(h.value(), UTF_8))
+  }
+
+  def existsHeader(key: String): Boolean = findHeader(key).isDefined
+
+  def headersScala: Map[String, String] = cr.headers()
+    .asScala
+    .map(h => h.key() -> new String(h.value(), UTF_8))(breakOut)
+
+}
+
 /**
   * Util that contains the implicits to create enriched values.
   */
@@ -47,5 +69,7 @@ object Implicits {
   implicit def enrichedInstant(instant: Instant): EnrichedInstant = EnrichedInstant(instant)
 
   implicit def enrichedIterator[T](iterator: Iterator[T])(implicit ec: ExecutionContext): EnrichedIterator[T] = EnrichedIterator[T](iterator)
+
+  implicit def enrichedConsumerRecord[K, V](cr: ConsumerRecord[K, V]): EnrichedConsumerRecord[K, V] = EnrichedConsumerRecord[K, V](cr)
 
 }

--- a/src/main/scala/com/ubirch/kafka/util/Implicits.scala
+++ b/src/main/scala/com/ubirch/kafka/util/Implicits.scala
@@ -8,7 +8,6 @@ import org.joda.time.{ Duration, Instant }
 
 import scala.collection.JavaConverters._
 import scala.collection.breakOut
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 import scala.language.implicitConversions
 
@@ -68,7 +67,7 @@ object Implicits {
 
   implicit def enrichedInstant(instant: Instant): EnrichedInstant = EnrichedInstant(instant)
 
-  implicit def enrichedIterator[T](iterator: Iterator[T])(implicit ec: ExecutionContext): EnrichedIterator[T] = EnrichedIterator[T](iterator)
+  implicit def enrichedIterator[T](iterator: Iterator[T]): EnrichedIterator[T] = EnrichedIterator[T](iterator)
 
   implicit def enrichedConsumerRecord[K, V](cr: ConsumerRecord[K, V]): EnrichedConsumerRecord[K, V] = EnrichedConsumerRecord[K, V](cr)
 

--- a/src/test/scala/com/ubirch/kafka/consumer/ConsumerRunnerSpec.scala
+++ b/src/test/scala/com/ubirch/kafka/consumer/ConsumerRunnerSpec.scala
@@ -19,7 +19,8 @@ import scala.language.{ implicitConversions, postfixOps }
 
 class ConsumerRunnerSpec extends TestBase {
 
-  implicit def executionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(5))
+  implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(5))
+  implicit val scheduler = monix.execution.Scheduler(ec)
 
   def processResult(_consumerRecords: Vector[ConsumerRecord[String, String]]) = new ProcessResult[String, String] {
     override val id: UUID = UUID.randomUUID()


### PR DESCRIPTION
- Adding new send method in producer trait to allow to send direct producer messages
- Adding helpers to search for headers
- Removing not needed execution contexts
- Setting scheduler as part of the main execution 
- Making the compiler happier
- Upgrading Monix version
- Removing deprecated method in commit logic
- Upgrading scala version to 2.12.8
- Adding some helpers to process consumer records: sync, task, obs