### PR TITLE
Feature/uc 1718 update jackson library

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ with the method *send*.
         <dependency>
             <groupId>com.ubirch</groupId>
             <artifactId>ubirch-kafka-express</artifactId>
-            <version>1.2.13-SNAPSHOT</version>
+            <version>1.2.14-SNAPSHOT</version>
         </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -38,14 +38,14 @@
     </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>gitlab-maven</id>
+            <url>https://gitlab.com/api/v4/projects/37429227/packages/maven</url>
         </repository>
+        <snapshotRepository>
+            <id>gitlab-maven</id>
+            <url>https://gitlab.com/api/v4/projects/37429227/packages/maven</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <!-- basic info -->
     <groupId>com.ubirch</groupId>
     <artifactId>ubirch-kafka-express</artifactId>
-    <version>1.2.13-SNAPSHOT</version>
+    <version>1.2.14-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>Simple wrapper for starting a kafka consumer or producer very quickly</description>
     <url>https://ubirch.com</url>
@@ -34,7 +34,7 @@
         <connection>scm:git:git@github.com:ubirch/ubirch-kafka-express.git</connection>
         <developerConnection>scm:git:git@github.com:ubirch/ubirch-kafka-express.git</developerConnection>
         <url>https://github.com/ubirch/ubirch-kafka-express</url>
-        <tag>1.2.13-SNAPSHOT</tag>
+        <tag>1.2.14-SNAPSHOT</tag>
     </scm>
 
     <distributionManagement>
@@ -69,23 +69,24 @@
         <!-- versions -->
 
         <io.monix.version>3.1.0</io.monix.version>
-        <kafka-clients.version>2.3.0</kafka-clients.version>
-        <embedded-kafka>2.3.0</embedded-kafka>
-        <json4s-native.version>3.6.0</json4s-native.version>
-        <json4s-jackson.version>3.6.1</json4s-jackson.version>
-        <json4s-ext>3.6.0</json4s-ext>
+        <kafka-clients.version>3.3.2</kafka-clients.version>
+        <embedded-kafka>3.3.2</embedded-kafka>
+        <json4s-native.version>4.0.6</json4s-native.version>
+        <json4s-jackson.version>4.0.6</json4s-jackson.version>
+        <json4s-ext>4.0.6</json4s-ext>
 
         <scala.logging.version>3.9.0</scala.logging.version>
         <slf4j.api.version>1.7.15</slf4j.api.version>
         <logback-classic.version>1.2.3</logback-classic.version>
         <log4j-over-slf4j.version>1.7.25</log4j-over-slf4j.version>
         <jcl-over-slf4j.version>1.7.25</jcl-over-slf4j.version>
-        <logstash-logback-encoder.version>5.3</logstash-logback-encoder.version>
+        <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
+
 
         <io.prometheus.simpleclient.version>0.6.0</io.prometheus.simpleclient.version>
         <io.prometheus.simpleclient_hotspot.version>0.6.0</io.prometheus.simpleclient_hotspot.version>
         <io.prometheus.simpleclient_httpserver.version>0.6.0</io.prometheus.simpleclient_httpserver.version>
-        <io.prometheus.simpleclient_logback.version>0.6.0</io.prometheus.simpleclient_logback.version>
+        <io.prometheus.simpleclient_logback.version>0.15.0</io.prometheus.simpleclient_logback.version>
         <io.prometheus.simpleclient_graphite_bridge.version>0.6.0</io.prometheus.simpleclient_graphite_bridge.version>
 
         <!-- plugins -->
@@ -201,7 +202,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>collector</artifactId>
-            <version>0.13.0</version>
+            <version>0.17.2</version>
         </dependency>
 
         <!-- Prometheus -->
@@ -341,6 +342,12 @@
                 <configuration>
                     <skip>false</skip>
                 </configuration>
+            </plugin>
+            <!-- plugin to check for vulnerable dependencies; invoke by mvn org.owasp:dependency-check-maven:check -->
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>8.0.2</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,11 @@
         <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
 
 
-        <io.prometheus.simpleclient.version>0.6.0</io.prometheus.simpleclient.version>
-        <io.prometheus.simpleclient_hotspot.version>0.6.0</io.prometheus.simpleclient_hotspot.version>
-        <io.prometheus.simpleclient_httpserver.version>0.6.0</io.prometheus.simpleclient_httpserver.version>
+        <io.prometheus.simpleclient.version>0.15.0</io.prometheus.simpleclient.version>
+        <io.prometheus.simpleclient_hotspot.version>0.15.0</io.prometheus.simpleclient_hotspot.version>
+        <io.prometheus.simpleclient_httpserver.version>0.15.0</io.prometheus.simpleclient_httpserver.version>
         <io.prometheus.simpleclient_logback.version>0.15.0</io.prometheus.simpleclient_logback.version>
-        <io.prometheus.simpleclient_graphite_bridge.version>0.6.0</io.prometheus.simpleclient_graphite_bridge.version>
+        <io.prometheus.simpleclient_graphite_bridge.version>0.15.0</io.prometheus.simpleclient_graphite_bridge.version>
 
         <!-- plugins -->
         <scalariform.version>0.2.2</scalariform.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,9 @@
         <!-- versions -->
 
         <io.monix.version>3.1.0</io.monix.version>
+        <!-- Since 0.10.0.0, Kafka has a "bidirectional" client compatibility policy.
+               https://kafka.apache.org/protocol#protocol_compatibility 
+        -->
         <kafka-clients.version>3.3.2</kafka-clients.version>
         <embedded-kafka>3.3.2</embedded-kafka>
         <json4s-native.version>4.0.6</json4s-native.version>

--- a/src/main/scala/com/ubirch/kafka/consumer/Configs.scala
+++ b/src/main/scala/com/ubirch/kafka/consumer/Configs.scala
@@ -2,7 +2,6 @@ package com.ubirch.kafka.consumer
 
 import com.ubirch.kafka.util.ConfigProperties
 import org.apache.kafka.clients.consumer.{ ConsumerConfig, OffsetResetStrategy }
-import org.apache.kafka.common.requests.IsolationLevel
 
 /**
   * A convenience to manage the configuration keys that are used to
@@ -21,7 +20,6 @@ object Configs {
       maxPollInterval: Int = 300000,
       maxMetaDataAge: Long = 300000,
       autoOffsetReset: OffsetResetStrategy = OffsetResetStrategy.LATEST,
-      isolationLevel: IsolationLevel = IsolationLevel.READ_UNCOMMITTED,
       fetchMaxBytesConfig: Int = ConsumerConfig.DEFAULT_FETCH_MAX_BYTES,
       maxPartitionFetchBytesConfig: Int = ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES,
       reconnectBackoffMsConfig: Long = 50L,
@@ -41,7 +39,6 @@ object Configs {
           ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG -> maxPollInterval.toString,
           ConsumerConfig.METADATA_MAX_AGE_CONFIG -> maxMetaDataAge.toString,
           ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> autoOffsetReset.toString.toLowerCase,
-          ConsumerConfig.ISOLATION_LEVEL_CONFIG -> isolationLevel.toString.toLowerCase(),
           ConsumerConfig.FETCH_MAX_BYTES_CONFIG -> fetchMaxBytesConfig.toString,
           ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG -> maxPartitionFetchBytesConfig.toString,
           ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG -> reconnectBackoffMsConfig.toString,

--- a/src/main/scala/com/ubirch/kafka/consumer/WithProcessRecords.scala
+++ b/src/main/scala/com/ubirch/kafka/consumer/WithProcessRecords.scala
@@ -3,7 +3,6 @@ package com.ubirch.kafka.consumer
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
-
 import com.ubirch.kafka.util.Exceptions._
 import com.ubirch.kafka.util.FutureHelper
 import com.ubirch.kafka.util.Implicits._
@@ -12,6 +11,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
 
 import scala.collection.JavaConverters._
+import scala.collection.convert.ImplicitConversions.`map AsScala`
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 
@@ -148,7 +148,7 @@ trait WithProcessRecords[K, V] {
       val error = failed.get()
       if (error.isDefined) {
         consumerRecords.partitions().asScala.foreach { p =>
-          val offset = Option(consumer.committed(p)).map(_.offset()).getOrElse(0L)
+          val offset = Option(consumer.committed(Set(p).asJava).get(p)).map(_.offset()).getOrElse(0L)
           consumer.seek(p, offset)
         }
         failed.set(None)

--- a/src/main/scala/com/ubirch/kafka/metrics/PrometheusMetricsHelper.scala
+++ b/src/main/scala/com/ubirch/kafka/metrics/PrometheusMetricsHelper.scala
@@ -14,30 +14,30 @@ import scala.annotation.tailrec
 object PrometheusMetricsHelper extends LazyLogging {
 
   /**
-   * Simple and default connection backed up by the default registry
-   * @param port the port number to start the server on
-   * @param maxAttempts the number of retries for when there is a Connection problem.
-   *                    If not provided, 3 attempts will be performed
-   * @return the Prometheus Http Server
-   */
+    * Simple and default connection backed up by the default registry
+    * @param port the port number to start the server on
+    * @param maxAttempts the number of retries for when there is a Connection problem.
+    *                    If not provided, 3 attempts will be performed
+    * @return the Prometheus Http Server
+    */
   def default(port: Int, maxAttempts: Int = 3): HTTPServer = create(port, defaultCollectorRegistry, maxAttempts)
 
   /**
-   * Connection backed up by JMX registry. It will exports JMX values as Prometheus metrics.
-   * @param port the port number to start the server on
-   * @param maxAttempts the number of retries for when there is a Connection problem.
-   *                    If not provided, 3 attempts will be performed
-   * @return the Prometheus Http Server
-   */
+    * Connection backed up by JMX registry. It will exports JMX values as Prometheus metrics.
+    * @param port the port number to start the server on
+    * @param maxAttempts the number of retries for when there is a Connection problem.
+    *                    If not provided, 3 attempts will be performed
+    * @return the Prometheus Http Server
+    */
   def defaultWithJXM(port: Int, maxAttempts: Int = 3): HTTPServer = create(port, createCustomCollectorRegistry, maxAttempts)
 
   /**
-   * Represents a builder for the http server for prometheus
-   * @param port the port number to start the server on
-   * @param collectorRegistry the registry for the metrics
-   * @param maxAttempts the number of retries for when there is a Connection problem.
-   * @return the Prometheus Http Server
-   */
+    * Represents a builder for the http server for prometheus
+    * @param port the port number to start the server on
+    * @param collectorRegistry the registry for the metrics
+    * @param maxAttempts the number of retries for when there is a Connection problem.
+    * @return the Prometheus Http Server
+    */
   private final def create(port: Int, collectorRegistry: CollectorRegistry, maxAttempts: Int): HTTPServer = {
 
     @tailrec

--- a/src/test/scala/com/ubirch/TestBase.scala
+++ b/src/test/scala/com/ubirch/TestBase.scala
@@ -1,6 +1,6 @@
 package com.ubirch
 
-import net.manub.embeddedkafka.EmbeddedKafka
+import io.github.embeddedkafka.EmbeddedKafka
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, MustMatchers, WordSpec }
 

--- a/src/test/scala/com/ubirch/kafka/consumer/ConfigsSpec.scala
+++ b/src/test/scala/com/ubirch/kafka/consumer/ConfigsSpec.scala
@@ -21,7 +21,6 @@ class ConfigsSpec extends TestBase {
         ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG,
         ConsumerConfig.METADATA_MAX_AGE_CONFIG,
         ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
-        ConsumerConfig.ISOLATION_LEVEL_CONFIG,
         ConsumerConfig.FETCH_MAX_BYTES_CONFIG,
         ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG,
         ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG

--- a/src/test/scala/com/ubirch/kafka/consumer/ConsumerRunnerSpec.scala
+++ b/src/test/scala/com/ubirch/kafka/consumer/ConsumerRunnerSpec.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.{ CountDownLatch, Executors }
 import com.ubirch.TestBase
 import com.ubirch.kafka.util.Exceptions.{ CommitTimeoutException, NeedForPauseException }
 import com.ubirch.kafka.util.{ NameGiver, PortGiver }
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
+import io.github.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.consumer.{ ConsumerRecord, ConsumerRecords, OffsetResetStrategy }
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException

--- a/src/test/scala/com/ubirch/kafka/producer/ProducerRunnerSpec.scala
+++ b/src/test/scala/com/ubirch/kafka/producer/ProducerRunnerSpec.scala
@@ -3,7 +3,7 @@ package com.ubirch.kafka.producer
 import com.ubirch.TestBase
 import com.ubirch.kafka.util.Exceptions.ProducerCreationException
 import com.ubirch.kafka.util.PortGiver
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
+import io.github.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.errors.InvalidTopicException
 import org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
I updated the versions of the libraries used in kafka express to minimise the number of CVEs. 
(Mostly related to the jackson stuff, to eliminate further 7 CVEs I upgraded two libs related to prometheus)
I changed the code a bit to prevent error messages due to the newer libs. 